### PR TITLE
Bump version in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Deploy Ghost Theme
-        uses: TryGhost/action-deploy-theme@v1.2.0
+        uses: TryGhost/action-deploy-theme@v1.2.1
         with:
           api-url: ${{ secrets.GHOST_ADMIN_API_URL }}
           api-key: ${{ secrets.GHOST_ADMIN_API_KEY }}


### PR DESCRIPTION
The example config in the readme is out of date. 

It would also be helpful to have a latest tag that always points to the latest release, would it be possible to add that?