### PR TITLE
Delete unsupported `theme-name` config key in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ The `with` portion of the workflow **must** be configured before the action will
 | `api-url`  | The base URL of your Ghost Admin API, found by configuring a new Custom Integration in Ghost Admin&raquo;Integrations | `secrets` | **Yes** |
 | `api-key`  | The authentication key for your Ghost Admin API, found by configuring a new Custom Integration in Ghost Admin&raquo;Integrations | `secrets` | **Yes** |
 | `exclude` | A list of files & folders to exclude from the generated zip file in addition to the defaults, e.g. `"gulpfile.js *dist/*"` | `string` | No |
-| `theme-name` | A custom theme name that overrides the default name in package.json. Useful if you use a fork of Casper, e.g. `"my-theme"` | `string` | No |
 | `file` | Path to a built zip file. If this is included, the `exclude`, `string`, and `theme-name` options are ignored | `string` | No | 
 
 &nbsp;


### PR DESCRIPTION
As described in #22

`action.yml` does **not** include a `theme-name` key. Removed from documentation to avoid confusion and warning messages in use.