### PR TITLE
Return theme-name key to action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
   exclude:
     description: 'Files or folders to exclude (space-separated list)'
     required: false
+  theme-name:
+    description: 'A custom theme name that overrides the default name in package.json'
+    required: false
   file:
     description: 'Path to a built zip file. If this is included, the `exclude`, `string`, and `theme-name` options are ignored'
     required: false


### PR DESCRIPTION
As per #22, add `theme-name` back to the list of inputs within action.yml.

[Tested on own Casper fork](https://github.com/mrkwse/Casper-plus/runs/694175525?check_suite_focus=true) ([with `theme-name` defined](https://github.com/mrkwse/Casper-plus/blob/master/.github/workflows/deploy-test-theme.yml))

![image](https://user-images.githubusercontent.com/340723/82492974-0e81e600-9adf-11ea-807e-b1c4fa54de3a.png)
_Working as expected on personal test Ghost instance (casper-deploy-test)_