### PR TITLE
Changed Ubuntu version in example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ on:
       - main
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Deploy Ghost Theme


### PR DESCRIPTION
Ubuntu 18.04 is being deprecated with brownouts scheduled (and one already experied before the 18.04 EoL date was pushed back) as per: [The Ubuntu 18.04 Actions runner image will begin deprecation on 8/8/22 and will be fully unsupported by 4/1/2023](https://github.com/actions/runner-images/issues/6002)

Example config should be updated to reflect this.