### PR TITLE
Updated GHA Node version to v16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,5 +23,5 @@ inputs:
     description: 'A custom directory to zip when a theme is in a subdirectory'
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
GitHub has deprecated Node 12 for Actions: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Users now receive a warning when our action runs (which has caused one support ticket)

This updates the action to use Node 16. 