### PR TITLE
set version field to default to v5.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const GhostAdminApi = require('@tryghost/admin-api');
         const api = new GhostAdminApi({
             url,
             key: core.getInput('api-key'),
-            version: "v5.0"
+            version: 'v5.0'
         });
 
         const basePath = process.env.GITHUB_WORKSPACE;

--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ const GhostAdminApi = require('@tryghost/admin-api');
         const url = core.getInput('api-url');
         const api = new GhostAdminApi({
             url,
-            key: core.getInput('api-key')
+            key: core.getInput('api-key'),
+            version: "v5.0"
         });
 
         const basePath = process.env.GITHUB_WORKSPACE;

--- a/index.js
+++ b/index.js
@@ -8,8 +8,7 @@ const GhostAdminApi = require('@tryghost/admin-api');
         const url = core.getInput('api-url');
         const api = new GhostAdminApi({
             url,
-            key: core.getInput('api-key'),
-            version: 'canary'
+            key: core.getInput('api-key')
         });
 
         const basePath = process.env.GITHUB_WORKSPACE;


### PR DESCRIPTION
With the transition to an unversioned API, I removed `version: 'canary'` from the `GhostAdminApi` config, as it's optional and was generating warnings in the Action logs. These warnings were causing confusion among users.

Without the version field, the [API client will default to the unversioned path](https://github.com/TryGhost/SDK/blob/15de3b9618e3af31e967effd2ce28bc2a2c437fc/packages/admin-api/lib/admin-api.js#L26).

Ref: https://forum.ghost.org/t/github-actions-error/34731/8 #76 #79 