### PR TITLE
Slug the theme name from package.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const slug = require('slug');
 const core = require('@actions/core');
 const exec = require('@actions/exec');
 const GhostAdminApi = require('@tryghost/admin-api');
@@ -19,7 +20,7 @@ const GhostAdminApi = require('@tryghost/admin-api');
 
         // Zip file was not provided - zip everything up!
         if (!zipPath) {
-            const themeName = core.getInput('theme-name') || require(pkgPath).name;
+            const themeName = core.getInput('theme-name') || slug(require(pkgPath).name);
             const themeZip = `${themeName}.zip`;
             const exclude = core.getInput('exclude') || '';
             zipPath = themeZip;

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@actions/core": "1.10.0",
     "@actions/exec": "1.1.1",
-    "@tryghost/admin-api": "1.13.4"
+    "@tryghost/admin-api": "1.13.4",
+    "slug": "^8.2.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1318,6 +1318,11 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
+slug@^8.2.2:
+  version "8.2.2"
+  resolved "https://registry.yarnpkg.com/slug/-/slug-8.2.2.tgz#33b019a857a11fc4773c1e9a9f60e3da651a9e5d"
+  integrity sha512-5ByW6qXqPeG0Tmlkh24JhdXhvQsbaJSjVr3GgGxUV0BSskZKKBZZfFWxezap8+fh1vxBN9GVbqI1V6nqAFxlBg==
+
 snake-case@^3.0.3:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/snake-case/-/snake-case-3.0.4.tgz#4f2bbd568e9935abdfd593f34c691dadb49c452c"


### PR DESCRIPTION
The zipping fails when you have a more complex name defined in your package.json. Slugging prevents the zipping from crashing.

For example, we had a package named `madewithlove/theme`.