### PR TITLE
Use renovate-config repo directly for Renovate presets

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
   "extends": [
-    "@tryghost:quietJS"
+    "github>TryGhost/renovate-config"
   ]
 }


### PR DESCRIPTION
## Summary
- replace package-style `@tryghost:` preset usage with `github>TryGhost/renovate-config`
- standardize shared Renovate configuration on the dedicated renovate-config repository
- remove indirection from older preset reference patterns