### PR TITLE
Fixed deploy zips shipping pnpm files and repaired the broken build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,8 @@ jobs:
         node: [20, 22, 24]
     name: Node ${{ matrix.node }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node }}
       - run: yarn

--- a/index.js
+++ b/index.js
@@ -1,11 +1,16 @@
 const path = require('path');
-const slug = require('slug');
-const core = require('@actions/core');
-const exec = require('@actions/exec');
 const GhostAdminApi = require('@tryghost/admin-api');
 
 (async function main() {
     try {
+        // slug and the @actions toolkit packages are ESM-only in their current
+        // majors, so they must be loaded via dynamic import from CommonJS.
+        const [core, exec, {default: slug}] = await Promise.all([
+            import('@actions/core'),
+            import('@actions/exec'),
+            import('slug')
+        ]);
+
         const url = core.getInput('api-url');
         const api = new GhostAdminApi({
             url,
@@ -26,7 +31,7 @@ const GhostAdminApi = require('@tryghost/admin-api');
             zipPath = themeZip;
 
             // Create a zip
-            await exec.exec(`zip -r ${themeZip} . -x *.git* *.zip yarn* npm* node_modules* *routes.yaml *redirects.yaml *redirects.json ${exclude}`, [], {cwd: basePath});
+            await exec.exec(`zip -r ${themeZip} . -x *.git* *.zip yarn* npm* pnpm* node_modules* *routes.yaml *redirects.yaml *redirects.json ${exclude}`, [], {cwd: basePath});
         }
 
         zipPath = path.join(basePath, zipPath);


### PR DESCRIPTION
## Summary

Minimal source-only fix, two things:

1. **`pnpm*` added to the default zip excludes.** The exclude list covered `yarn*`/`npm*` but not `pnpm*`, so themes deployed from pnpm-based repos shipped `pnpm-lock.yaml` and `pnpm-workspace.yaml` into the live Ghost site. Found via TryGhost/Themes#529 — all 16 demo-site deploys there are affected, as are the standalone theme repos. Fixing it here covers the fleet centrally.
2. **Repaired the source so it builds again.** Renovate bumped `@actions/core` (3.x), `@actions/exec` (3.x), and `slug` (11.x) to ESM-only majors, after which `require()` of them fails and `ncc build` errors — `dist/` has not been rebuildable since February. The three packages are now loaded via dynamic `import()` from the CommonJS source.

**Note for merging:** this PR deliberately contains no `dist/` churn. Since the action executes from committed `dist/index.js`, `yarn build` must be run and its output committed when this ships (the `preship` script already wires build + lint).

A TypeScript conversion of this action (which also lets ncc bundle the ESM deps statically, single-file dist, plus a `check-dist` drift guard) is proposed separately as a follow-up PR.

## Verification

- `yarn build` (ncc 0.38.4) succeeds from this source; `yarn lint` clean
- Smoke test of the rebuilt bundle: all dynamic imports resolve, then it fails cleanly on the intentionally missing `api-url` input
- Zip simulation with the exact exclude pattern: `pnpm-workspace.yaml`/`pnpm-lock.yaml`/`yarn.lock` excluded, theme content kept
- The `exclude` input still appends to the list as documented