### PR TITLE
Update action runtime to node24, harden major-version workflow

### DIFF
--- a/.github/workflows/major.yml
+++ b/.github/workflows/major.yml
@@ -3,9 +3,13 @@ on:
   push:
     tags:
       - "v*"
+
+permissions:
+  contents: write
+
 jobs:
   update-major:
     name: Update Major Version Tag
     runs-on: ubuntu-latest
     steps:
-      - uses: nowactions/update-majorver@d95f48d454a24a603b30280450329e5b67a1b68a
+      - uses: nowactions/update-majorver@f2014bbbba95b635e990ce512c5653bd0f4753fb # v1.1.2

--- a/action.yml
+++ b/action.yml
@@ -27,5 +27,5 @@ inputs:
     description: 'A custom directory to zip when a theme is in a subdirectory'
     required: false
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
Fixes #132

Two compliance fixes from auditing this repo against current GitHub Actions requirements:

## `action.yml`: `node20` → `node24`

Node 20 reached EOL in April 2026, and per [GitHub's deprecation schedule](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) runners begin defaulting JavaScript actions to Node 24 on **June 16th, 2026** (next week), with Node 20 removed from the runner entirely in fall 2026. Declaring `node24` keeps the action on a supported runtime instead of relying on the forced migration. Self-hosted runners need ≥ 2.327.1.

No bundle changes required — `dist/` is runtime-agnostic here and CI already tests on Node 24.

## `major.yml` hardening

- **`permissions: contents: write`** — `nowactions/update-majorver` pushes the `v1` major tag, which fails under a read-only default workflow token. The workflow currently relies on the repo's implicit default; the last tag push predates run-log retention, so there's no evidence it still works. Making the grant explicit follows least-privilege convention used in the other workflows.
- **Re-pinned `update-majorver`** from `d95f48d` — an arbitrary commit on its main branch (a Renovate eslint bump from July 2025) — to `f2014bb`, the commit the `v1.1.2` release tag dereferences to, with a version comment so Renovate can track future releases.

## Worth a release after merging

The remote `v1` tag still points at v1.6.6 (February 2024). Everything since — the TypeScript conversion (#138), admin-api updates, the v6.0 default — is unreleased, so consumers on `@v1` run a 2-year-old bundle. Once this merges, a `pnpm ship` (after #144) would bring them current along with the node24 runtime.
