### PR TITLE
Exempt Renovate PRs from check-dist, self-heal dist on main

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -1,5 +1,11 @@
 # `dist/index.js` is what the runner actually executes, so it must always be
-# the build output of the current source. This guard fails when they drift.
+# the build output of the current source.
+#
+# Human PRs are expected to commit a rebuilt dist/ - the check-dist job fails
+# when source and dist drift. Renovate PRs are exempt: Renovate only bumps
+# manifests and can't rebuild dist, so the sync-dist job rebuilds dist on
+# every push to main and commits the result if it changed. That keeps main
+# releasable after auto-merged dependency updates.
 name: Check dist
 on:
   push:
@@ -12,6 +18,7 @@ permissions:
 
 jobs:
   check-dist:
+    if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -31,4 +38,31 @@ jobs:
             echo "Detected uncommitted changes after build. Run 'pnpm build' and commit dist/."
             git diff --stat --ignore-space-at-eol --text dist/
             exit 1
+          fi
+
+  sync-dist:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: sync-dist-main
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - name: Commit rebuilt dist if it drifted
+        run: |
+          if [ -n "$(git status --porcelain dist/)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add dist/
+            git commit -m "Rebuilt dist after dependency updates"
+            git push
           fi

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -55,14 +55,30 @@ jobs:
           node-version: 24
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm build
-      - name: Commit rebuilt dist if it drifted
+      # Always rebuild against the fetched tip of main, not the trigger
+      # commit: main may have moved since this run was triggered. If the
+      # push still loses a race, the rebuild retries once against the new
+      # tip - and the push that moved main has its own sync-dist run queued
+      # behind this one anyway.
+      - name: Rebuild dist against the tip of main and commit if drifted
         run: |
-          if [ -n "$(git status --porcelain dist/)" ]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          for attempt in 1 2; do
+            git fetch origin main
+            git reset --hard FETCH_HEAD
+            pnpm install --frozen-lockfile
+            pnpm build
+            if [ -z "$(git status --porcelain dist/)" ]; then
+              echo "dist matches the build output - nothing to sync"
+              exit 0
+            fi
             git add dist/
             git commit -m "Rebuilt dist after dependency updates"
-            git push
-          fi
+            if git push origin HEAD:main; then
+              exit 0
+            fi
+            echo "main moved during the rebuild (attempt $attempt), retrying against the new tip"
+          done
+          echo "Failed to push the rebuilt dist after 2 attempts"
+          exit 1


### PR DESCRIPTION
Unblocks Renovate automerge. The org Renovate preset automerges dependency updates, but automerge waits for **every** check on the PR head to be green — and check-dist can never pass on a Renovate PR, since Renovate only bumps manifests and can't rebuild the committed ncc bundle. Every dependency PR was stuck behind a guaranteed-red check.

## How it works now

- **`check-dist`** keeps enforcing "source and dist must match" where the contract can actually be met: human PRs, which are expected to commit a rebuilt `dist/`. Renovate PRs skip it (same `head_ref` condition test.yml already uses), and a skipped check doesn't block automerge.
- **`sync-dist`** (new job, push-to-main only) rebuilds `dist/` and commits the result as `github-actions[bot]` if it drifted. The same guarantee Renovate PRs are exempted from is restored immediately post-merge, so main stays releasable after auto-merged updates.

## Safety properties

- The ncc build is deterministic (verified twice on earlier PRs), so when dist is already in sync the job produces no commit — no commit loops
- A `concurrency` group serialises competing pushes from back-to-back automerges
- `contents: write` is scoped to the sync-dist job only; check-dist keeps the read-only token and `persist-credentials: false`

## Trade-off

The sync commit is pushed with `GITHUB_TOKEN`, which doesn't trigger new workflow runs — so Test won't re-run on the sync commit itself. The identical dependency state was already tested on the Renovate branch (test.yml runs on `renovate/*` pushes), so no coverage is lost. If we ever want CI on sync commits too, the job would need a GitHub App or PAT instead.

Once merged, the currently-red Renovate PRs should automerge after their next rebase.