### PR TITLE
Use pro-ship for action-deploy-theme releases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,8 +18,9 @@ This is a guide for developing and contributing to this GitHub Action. By instal
 
 ## Publish
 
-- `pnpm ship` runs typecheck, lint & build, then bumps the patch version, tags and pushes
-- `BUMP=minor pnpm ship` (or `BUMP=major`) for larger version bumps
+- `pnpm ship patch` runs typecheck, lint & build, then bumps, commits, tags and pushes
+- `pnpm ship minor` or `pnpm ship major` for larger version bumps
+- `pnpm ship 2.1.0` for an explicit version
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "format": "oxfmt .",
     "typecheck": "tsc --noEmit",
     "preship": "pnpm typecheck && pnpm lint && pnpm build",
-    "ship": "STATUS=$(git status --porcelain); echo $STATUS; if [ -z \"$STATUS\" ]; then pnpm version \"${BUMP:-patch}\" && git push --follow-tags; fi"
+    "ship": "pro-ship"
   },
   "dependencies": {
     "@actions/core": "3.0.1",
@@ -26,6 +26,7 @@
     "slug": "11.0.1"
   },
   "devDependencies": {
+    "@tryghost/pro-ship": "1.1.2",
     "@types/node": "25.9.4",
     "@types/slug": "5.0.9",
     "oxfmt": "0.55.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
         specifier: 11.0.1
         version: 11.0.1
     devDependencies:
+      '@tryghost/pro-ship':
+        specifier: 1.1.2
+        version: 1.1.2
       '@types/node':
         specifier: 25.9.4
         version: 25.9.4
@@ -301,6 +304,14 @@ packages:
   '@tryghost/admin-api@1.14.10':
     resolution: {integrity: sha512-B7Ov1Y/VhuNFsvDyN6DsNFcoqjpUccNrYFXsK5oy9sobZ/6AoRRW2kI4SHn4hrCcP89xPipVhTMcmhvoh0IhvQ==}
 
+  '@tryghost/pro-ship@1.1.2':
+    resolution: {integrity: sha512-o20xQ/kFbwvq9NylXN+/G3kxNAKNicFPOysAL+MspjStFftThGBj7miCgedWscZoQscDsb/6uKPFgRUyHti7Mw==}
+    engines: {node: '>=20.20.0'}
+    hasBin: true
+
+  '@tryghost/root-utils@2.3.1':
+    resolution: {integrity: sha512-1g0HskTTDJzn3CzcEWhd4aKtcmPm3IztD7cyfQQiG4QX+6gfpPOkYk7Y5gDOwTKAYtfor0nc8npSY90vvIj93A==}
+
   '@types/node@25.9.4':
     resolution: {integrity: sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==}
 
@@ -327,6 +338,9 @@ packages:
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
+
+  caller@1.1.0:
+    resolution: {integrity: sha512-n+21IZC3j06YpCWaxmUy5AnVqhmCIM2bQtqQyy00HJlmStRt6kwDX5F9Z97pqwAB+G/tgSz6q/kUBbNyQzIubw==}
 
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
@@ -367,6 +381,9 @@ packages:
   es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
+
+  find-root@1.1.0:
+    resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
 
   follow-redirects@1.16.0:
     resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
@@ -661,6 +678,16 @@ snapshots:
       - debug
       - supports-color
 
+  '@tryghost/pro-ship@1.1.2':
+    dependencies:
+      '@tryghost/root-utils': 2.3.1
+      semver: 7.8.5
+
+  '@tryghost/root-utils@2.3.1':
+    dependencies:
+      caller: 1.1.0
+      find-root: 1.1.0
+
   '@types/node@25.9.4':
     dependencies:
       undici-types: 7.24.6
@@ -693,6 +720,8 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
+
+  caller@1.1.0: {}
 
   combined-stream@1.0.8:
     dependencies:
@@ -728,6 +757,8 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.4
+
+  find-root@1.1.0: {}
 
   follow-redirects@1.16.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+minimumReleaseAgeExclude:
+  - '@tryghost/pro-ship@1.1.2'
+  - '@tryghost/root-utils@2.3.1'


### PR DESCRIPTION
## Summary
- add @tryghost/pro-ship and use it for `pnpm ship`
- replace the inline `pnpm version` and `git push --follow-tags` release script
- update contributor release docs for explicit release-type and version arguments

## Validation
- `pnpm install --frozen-lockfile && pnpm typecheck && pnpm lint && pnpm build`