### PR TITLE
Improve repository documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# AGENTS.md
+
+This is a Node.js 24 GitHub Action that packages and uploads Ghost themes; see [README.md](README.md) for usage.
+
+- Use the pnpm version declared in `package.json`. Install with `pnpm install --frozen-lockfile`.
+- Validate changes with `pnpm lint`, `pnpm typecheck`, and `pnpm build`.
+- The runner executes committed `dist/index.js`. Never edit `dist/` by hand; human-authored source or bundled dependency changes must include the output from `pnpm build`.
+- Renovate pull requests are exempt from committing rebuilt `dist/`. The `sync-dist` workflow rebuilds the bundle on `main` after Renovate changes merge.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,24 +1,32 @@
 # 🛠 Ghost Theme Deploy for GitHub Actions (DEV)
 
-This is a guide for developing and contributing to this GitHub Action. By installing and running this Action manually, you'll be able to control the environment variables that GitHub usually applies to the Action's container.
+This guide covers local development, validation, and releases for the GitHub Action.
 
 ---
 
 ## Develop
 
-1. `git clone` this repo & `cd` into it as usual
-2. Run `pnpm install` to install top-level dependencies.
+Use Node.js 24 and the pnpm version declared in `package.json`:
 
-## Test
+```sh
+corepack enable
+pnpm install --frozen-lockfile
+```
 
-- `pnpm lint` run oxlint and check formatting with oxfmt
-- `pnpm lint:fix` auto-fix lint issues and reformat
-- `pnpm typecheck` run the TypeScript compiler checks
-- `pnpm build` bundle the action into `dist/` with ncc
+## Validate
+
+- `pnpm lint` runs oxlint and checks formatting with oxfmt
+- `pnpm lint:fix` fixes supported lint issues and reformats files
+- `pnpm typecheck` runs the TypeScript compiler checks
+- `pnpm build` bundles the action into `dist/` with ncc
+
+GitHub Actions runs `dist/index.js`, so the built output is committed. For human-authored changes to the source or bundled dependencies, run `pnpm build` and commit the resulting `dist/` changes. Do not edit `dist/` by hand. CI verifies that the committed bundle matches the source.
+
+Renovate pull requests are the exception: Renovate updates manifests without rebuilding `dist/`. After those changes reach `main`, the `sync-dist` workflow rebuilds and commits any bundle changes.
 
 ## Publish
 
-- `pnpm ship patch` runs typecheck, lint & build, then bumps, commits, tags and pushes
+- `pnpm ship patch` runs typecheck, lint and build, then bumps, commits, tags and pushes
 - `pnpm ship minor` or `pnpm ship major` for larger version bumps
 - `pnpm ship 2.1.0` for an explicit version
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 </p>
 
 <p align="center">
-    This <a href="https://github.com/features/actions">GitHub action</a> allows you to automatically build and deploy your <a href="https://ghost.org/docs/api/handlebars-themes/">Ghost Theme</a> <br>from GitHub to any <a href="https://ghost.org">Ghost</a> install, via the Ghost Admin API!
+    This <a href="https://github.com/features/actions">GitHub Action</a> packages and deploys your <a href="https://docs.ghost.org/themes/">Ghost theme</a> <br>from GitHub to a <a href="https://ghost.org">Ghost</a> site through the Ghost Admin API.
 </p>
 
 <p align="center">
@@ -36,8 +36,6 @@
 &nbsp;
 
 ## Getting Started
-
-💡 This action expects that you already have a working Ghost install running at least v2.25.5.
 
 1. Generate a set of Ghost Admin API credentials, by configuring a new Custom Integration in Ghost Admin &rarr; Integrations.
 
@@ -56,7 +54,7 @@ jobs:
     deploy:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - name: Deploy Ghost Theme
               uses: TryGhost/action-deploy-theme@v2
               with:
@@ -64,21 +62,21 @@ jobs:
                   api-key: ${{ secrets.GHOST_ADMIN_API_KEY }}
 ```
 
-This will trigger a deployment for every commit to master. If you'd like to change the "on" event, see the [GitHub action documentation](https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#on), which shows how to build on Pull Requests, Releases, Tags and more.
+This workflow deploys the theme after every push to `master` or `main`. To use a different trigger, see GitHub's [workflow trigger documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows).
 
 ## Configuration
 
-The `with` portion of the workflow **must** be configured before the action will work. Any `secrets` must be referenced using the bracket syntax and stored in the GitHub repositories `Settings/Secrets` menu. You can learn more about setting environment variables with GitHub actions [here](https://help.github.com/en/articles/workflow-syntax-for-github-actions#jobsjob_idstepsenv).
+The `with` section must provide the API URL and key. Store both values under the repository's **Settings &rarr; Secrets and variables &rarr; Actions**, then reference them with the `secrets` context as shown above. See GitHub's guide to [using secrets in GitHub Actions](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets).
 
-| Key                 | Value Information                                                                                                                                                                                       | Type      | Required |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | -------- |
-| `api-url`           | The base URL of your Ghost Admin API, found by configuring a new Custom Integration in Ghost Admin &rarr; Integrations                                                                                  | `secrets` | **Yes**  |
-| `api-key`           | The authentication key for your Ghost Admin API, found by configuring a new Custom Integration in Ghost Admin &rarr; Integrations                                                                       | `secrets` | **Yes**  |
-| `version`           | The GhostJS version your blog is in. This will be [passed in the headers](https://docs.ghost.org/admin-api#accept-version-header) via `GhostAdminApi` package. Defaults to the latest version `v6.0`    | `string`  | No       |
-| `exclude`           | A list of files & folders to exclude from the generated zip file in addition to the [defaults](https://github.com/TryGhost/action-deploy-theme/tree/main/src/main.ts#L31), e.g. `"gulpfile.js *dist/*"` | `string`  | No       |
-| `theme-name`        | A custom theme name that overrides the default name in package.json. Useful if you use a fork of Casper, e.g. `"my-theme"`                                                                              | `string`  | No       |
-| `file`              | Path to a built zip file. If this is included, the `exclude` and `theme-name` options are ignored                                                                                                       | `string`  | No       |
-| `working-directory` | A custom directory to zip when a theme is in a subdirectory, e.g. `packages/my-theme`                                                                                                                   | `string`  | No       |
+| Key                 | Value Information                                                                                                                                                                                                     | Type     | Required |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | -------- |
+| `api-url`           | The base URL of your Ghost Admin API, found by configuring a new Custom Integration in Ghost Admin &rarr; Integrations                                                                                                | `string` | **Yes**  |
+| `api-key`           | The authentication key for your Ghost Admin API, found by configuring a new Custom Integration in Ghost Admin &rarr; Integrations                                                                                     | `string` | **Yes**  |
+| `version`           | The [minimum Ghost Admin API version](https://docs.ghost.org/admin-api/#accept-version-header) the action expects the target site to support. Defaults to `v6.0`                                                      | `string` | No       |
+| `exclude`           | A space-separated list of files and folders to exclude from the generated zip file in addition to the [defaults](https://github.com/TryGhost/action-deploy-theme/blob/main/src/main.ts), e.g. `"gulpfile.js *dist/*"` | `string` | No       |
+| `theme-name`        | A custom theme name that overrides the default name in package.json. Useful if you use a fork of Casper, e.g. `"my-theme"`                                                                                            | `string` | No       |
+| `file`              | Path to a built zip file. If this is included, the `exclude` and `theme-name` options are ignored                                                                                                                     | `string` | No       |
+| `working-directory` | A custom directory to zip when a theme is in a subdirectory, e.g. `packages/my-theme`                                                                                                                                 | `string` | No       |
 
 &nbsp;
 
@@ -89,6 +87,10 @@ The `with` portion of the workflow **must** be configured before the action will
 ---
 
 <p align="center">Don't forget to 🌟 Star 🌟 the repo if you like this GitHub Action!</p>
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the development, validation, and release commands.
 
 # Copyright & License
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'Deploy Ghost Theme'
-description: 'Build & deploy a theme to your Ghost site'
+description: 'Package and upload a theme to your Ghost site'
 branding:
   icon: 'cloud-lightning'
   color: 'gray-dark'
@@ -11,7 +11,7 @@ inputs:
     description: 'Ghost Admin API Key'
     required: true
   version:
-    description: 'Ghost Version'
+    description: 'Minimum Ghost Admin API version'
     required: false
     default: 'v6.0'
   exclude:


### PR DESCRIPTION
## Summary

- correct the GitHub Action's packaging, upload, secret, trigger, and Admin API version documentation
- document the Node 24, pnpm, validation, committed `dist`, Renovate sync, and release workflows
- add concise agent guidance through `AGENTS.md` and a `CLAUDE.md` symlink
- align the public `action.yml` descriptions with the action's actual behavior

## Repo-audit docs ledger

- README: updated with current, source-backed usage and input details
- AGENTS: added non-obvious operational rules and commands
- Supporting docs: improved the existing focused `CONTRIBUTING.md`; no new `/docs` page is warranted
- Diagrams: not applicable for this short linear action flow
- GitHub description: will be updated after this PR merges, using the finished README as its source

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- parsed `action.yml`
- verified `CLAUDE.md` points to `AGENTS.md`
- `git diff --check`
- confirmed rebuilding leaves `dist/index.js` unchanged
