### PR TITLE
Use a team-owned PAT for dist synchronization

### DIFF
--- a/.github/workflows/sync-dist.yml
+++ b/.github/workflows/sync-dist.yml
@@ -70,8 +70,6 @@ jobs:
     if: needs.rebuild-dist.outputs.changed == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 5
-    permissions:
-      contents: write # Push the generated bundle back to main.
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -86,14 +84,22 @@ jobs:
         shell: bash
         env:
           BASE_SHA: ${{ needs.rebuild-dist.outputs.base-sha }}
-          GITHUB_TOKEN: ${{ github.token }}
+          SYNC_DIST_GH_TOKEN: ${{ secrets.SYNC_DIST_GH_TOKEN }}
         run: |
+          if [ -z "$SYNC_DIST_GH_TOKEN" ]; then
+            echo "::error::SYNC_DIST_GH_TOKEN is not configured"
+            exit 1
+          fi
+
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add dist/
           git commit -m "Rebuilt dist after dependency updates"
 
-          auth_header=$(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')
+          # This is a fine-grained PAT limited to this repository with only
+          # Contents: read and write. Its owner belongs to Ghost Foundation so
+          # the standard ruleset permits this generated commit on main.
+          auth_header=$(printf 'x-access-token:%s' "$SYNC_DIST_GH_TOKEN" | base64 | tr -d '\n')
           if git -c http.https://github.com/.extraheader="AUTHORIZATION: basic $auth_header" push origin HEAD:main; then
             exit 0
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,3 +6,4 @@ This is a Node.js 24 GitHub Action that packages and uploads Ghost themes; see [
 - Validate changes with `pnpm preship`; use `pnpm test` for a faster test-only run.
 - The runner executes committed `dist/index.js`. Never edit `dist/` by hand; human-authored source or bundled dependency changes must include the output from `pnpm build`.
 - Renovate pull requests are exempt from committing rebuilt `dist/`. The `sync-dist` workflow rebuilds the bundle on `main` after Renovate changes merge.
+- `sync-dist` authenticates its final push with the `SYNC_DIST_GH_TOKEN` repository secret. Provision it as a fine-grained PAT limited to this repository with only `Contents: read and write`; its owner must remain in the Ghost Foundation team so the standard ruleset bypass applies. Do not grant Actions, workflow, or administration permissions, and do not replace it with `GITHUB_TOKEN`.


### PR DESCRIPTION
## Why

The standard repository ruleset requires pull requests for changes to `main`. The workflow-scoped `GITHUB_TOKEN` cannot be added as a ruleset bypass actor, so `sync-dist` needs a narrowly scoped team-owned credential for its generated bundle commit.

## What changed

- keep the workflow `GITHUB_TOKEN` read-only
- expose `SYNC_DIST_GH_TOKEN` only to the final push step, after dependency installation and the build
- fail explicitly when the secret is absent
- document the provisioning contract: a fine-grained PAT limited to this repository with only Contents read/write, owned by a Ghost Foundation team member

## Required before merge

Provision `SYNC_DIST_GH_TOKEN` as a repository or selected organization secret. Do not merge this PR or apply the standard ruleset until that secret is available to this repository.

## Validation

- `pnpm preship`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm audit --audit-level high`
- `actionlint .github/workflows/*.yml`
- `git diff --check`
- independent credential and race-behavior review