### PR TITLE
Harden theme archive path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,15 @@ The `with` section must provide the API URL and key. Store both values under the
 | `api-key`           | The authentication key for your Ghost Admin API, found by configuring a new Custom Integration in Ghost Admin &rarr; Integrations                                                                                     | `string` | **Yes**  |
 | `version`           | The [minimum Ghost Admin API version](https://docs.ghost.org/admin-api/#accept-version-header) the action expects the target site to support. Defaults to `v6.0`                                                      | `string` | No       |
 | `exclude`           | A space-separated list of files and folders to exclude from the generated zip file in addition to the [defaults](https://github.com/TryGhost/action-deploy-theme/blob/main/src/main.ts), e.g. `"gulpfile.js *dist/*"` | `string` | No       |
-| `theme-name`        | A custom theme name that overrides the default name in package.json. Useful if you use a fork of Casper, e.g. `"my-theme"`                                                                                            | `string` | No       |
-| `file`              | Path to a built zip file. If this is included, the `exclude` and `theme-name` options are ignored                                                                                                                     | `string` | No       |
-| `working-directory` | A custom directory to zip when a theme is in a subdirectory, e.g. `packages/my-theme`                                                                                                                                 | `string` | No       |
+| `theme-name`        | A filename-safe custom theme name that overrides the default name in package.json. Useful if you use a fork of Casper, e.g. `"my-theme"`                                                                              | `string` | No       |
+| `file`              | Path to a trusted, built zip file, resolved from `working-directory`. The path must stay inside the workspace. If set, `exclude` and `theme-name` are ignored                                                         | `string` | No       |
+| `working-directory` | A directory inside the workspace to zip when a theme is in a subdirectory, e.g. `packages/my-theme`                                                                                                                   | `string` | No       |
 
 &nbsp;
 
 :bulb: Use `exclude` to reduce the size of the zip file & keep deployment times minimal.
+
+Generated archives reject symbolic links in the theme source so files outside the workspace cannot be packaged accidentally. This applies even when a symlink matches a custom `exclude` pattern; paths covered by the action's built-in exclusions are ignored. Prebuilt archives supplied with `file` are uploaded as-is and should come from a trusted build step.
 
 &nbsp;
 

--- a/action.yml
+++ b/action.yml
@@ -18,13 +18,13 @@ inputs:
     description: 'Files or folders to exclude (space-separated list)'
     required: false
   theme-name:
-    description: 'A custom theme name that overrides the default name in package.json'
+    description: 'A filename-safe custom theme name that overrides the default name in package.json'
     required: false
   file:
-    description: 'Path to a built zip file. If this is included, the `exclude` and `theme-name` options are ignored'
+    description: 'Workspace-contained path to a built zip file, resolved from `working-directory`. If set, `exclude` and `theme-name` are ignored'
     required: false
   working-directory:
-    description: 'A custom directory to zip when a theme is in a subdirectory'
+    description: 'A workspace-contained directory to zip when a theme is in a subdirectory'
     required: false
 runs:
   using: 'node24'

--- a/dist/index.js
+++ b/dist/index.js
@@ -49986,6 +49986,87 @@ var admin_api_default = /*#__PURE__*/__nccwpck_require__.n(admin_api);
 
 
 
+function isWithin(directory, candidate) {
+    const relativePath = external_node_path_default().relative(directory, candidate);
+    return (relativePath === '' ||
+        (relativePath !== '..' &&
+            !relativePath.startsWith(`..${(external_node_path_default()).sep}`) &&
+            !external_node_path_default().isAbsolute(relativePath)));
+}
+function resolveExistingPathWithin(resolutionDirectory, boundaryDirectory, inputPath, inputName, boundaryName, expectedType) {
+    const candidate = external_node_path_default().resolve(resolutionDirectory, inputPath || '.');
+    if (external_node_path_default().isAbsolute(inputPath) || !isWithin(boundaryDirectory, candidate)) {
+        throw new Error(`${inputName} must resolve within ${boundaryName}`);
+    }
+    const realDirectory = external_node_fs_default().realpathSync(boundaryDirectory);
+    const realCandidate = external_node_fs_default().realpathSync(candidate);
+    if (!isWithin(realDirectory, realCandidate)) {
+        throw new Error(`${inputName} must resolve within ${boundaryName}`);
+    }
+    const candidateStats = external_node_fs_default().statSync(realCandidate);
+    if (expectedType === 'directory' && !candidateStats.isDirectory()) {
+        throw new Error(`${inputName} must be a directory`);
+    }
+    if (expectedType === 'file' && !candidateStats.isFile()) {
+        throw new Error(`${inputName} must be a regular file`);
+    }
+    return candidate;
+}
+function assertSafeThemeName(themeName) {
+    const containsControlCharacter = [...themeName].some((character) => {
+        const codePoint = character.charCodeAt(0);
+        return codePoint <= 0x1f || codePoint === 0x7f;
+    });
+    if (!themeName ||
+        themeName === '.' ||
+        themeName === '..' ||
+        themeName.startsWith('-') ||
+        /[/\\]/.test(themeName) ||
+        containsControlCharacter) {
+        throw new Error('theme-name must be a name, not a path');
+    }
+}
+function prepareArchivePath(directory, themeName) {
+    const archivePath = external_node_path_default().resolve(directory, `${themeName}.zip`);
+    if (external_node_fs_default().existsSync(archivePath)) {
+        const archiveStats = external_node_fs_default().lstatSync(archivePath);
+        if (!archiveStats.isFile() || archiveStats.isSymbolicLink()) {
+            throw new Error('Generated archive path must be a regular file');
+        }
+        external_node_fs_default().unlinkSync(archivePath);
+    }
+    return archivePath;
+}
+function isBuiltInExcluded(relativePath) {
+    const archivePath = relativePath.split((external_node_path_default()).sep).join('/');
+    return (archivePath.includes('.git') ||
+        archivePath.endsWith('.zip') ||
+        /^(?:yarn|npm|pnpm|node_modules)/.test(archivePath) ||
+        archivePath === 'AGENTS.md' ||
+        archivePath === 'CLAUDE.md' ||
+        archivePath === 'pnpm-workspace.yaml' ||
+        archivePath.endsWith('routes.yaml') ||
+        archivePath.endsWith('redirects.yaml') ||
+        archivePath.endsWith('redirects.json'));
+}
+function assertSafeThemeSource(directory, currentDirectory = directory) {
+    for (const entry of external_node_fs_default().readdirSync(currentDirectory, { withFileTypes: true })) {
+        const entryPath = external_node_path_default().join(currentDirectory, entry.name);
+        const relativePath = external_node_path_default().relative(directory, entryPath);
+        if (isBuiltInExcluded(relativePath)) {
+            continue;
+        }
+        if (entry.isSymbolicLink()) {
+            throw new Error(`Theme source must not contain symlinks: ${relativePath}`);
+        }
+        if (entry.isDirectory()) {
+            assertSafeThemeSource(directory, entryPath);
+        }
+        else if (!entry.isFile()) {
+            throw new Error(`Theme source contains an unsupported file: ${relativePath}`);
+        }
+    }
+}
 async function run() {
     try {
         const url = getInput('api-url');
@@ -49994,24 +50075,35 @@ async function run() {
             key: getInput('api-key'),
             version: getInput('version') || 'v6.0',
         });
-        const workingDir = getInput('working-directory');
-        const basePath = external_node_path_default().join(process.env.GITHUB_WORKSPACE ?? '', workingDir);
-        const pkgPath = external_node_path_default().join(basePath, 'package.json');
+        const workspace = process.env.GITHUB_WORKSPACE;
+        if (!workspace) {
+            throw new Error('GITHUB_WORKSPACE is not set');
+        }
+        const workspacePath = external_node_path_default().resolve(workspace);
+        external_node_fs_default().realpathSync(workspacePath);
+        const basePath = resolveExistingPathWithin(workspacePath, workspacePath, getInput('working-directory'), 'working-directory', 'GITHUB_WORKSPACE', 'directory');
         let zipPath = getInput('file');
         // Zip file was not provided - zip everything up!
         if (!zipPath) {
+            const pkgPath = resolveExistingPathWithin(basePath, workspacePath, 'package.json', 'package.json', 'GITHUB_WORKSPACE', 'file');
             const pkg = JSON.parse(external_node_fs_default().readFileSync(pkgPath, 'utf8'));
+            if (typeof pkg.name !== 'string' || !pkg.name.trim()) {
+                throw new Error('package.json must contain a non-empty string name');
+            }
             const themeName = getInput('theme-name') || slug_slug(pkg.name);
+            assertSafeThemeName(themeName);
             const themeZip = `${themeName}.zip`;
             const excludeRaw = getInput('exclude').trim();
             const excludeArgs = excludeRaw ? excludeRaw.split(/\s+/) : [];
             if (excludeArgs.some((pattern) => pattern.startsWith('-'))) {
                 throw new Error('Invalid exclude pattern: option-like values are not allowed');
             }
-            zipPath = themeZip;
+            assertSafeThemeSource(basePath);
+            zipPath = prepareArchivePath(basePath, themeName);
             // Create a zip
             await exec_exec('zip', [
                 '-r',
+                '-y',
                 themeZip,
                 '.',
                 '-x',
@@ -50029,8 +50121,13 @@ async function run() {
                 '*redirects.json',
                 ...excludeArgs,
             ], { cwd: basePath });
+            if (!external_node_fs_default().lstatSync(zipPath).isFile()) {
+                throw new Error('Generated archive path must be a regular file');
+            }
         }
-        zipPath = external_node_path_default().join(basePath, zipPath);
+        else {
+            zipPath = resolveExistingPathWithin(basePath, workspacePath, zipPath, 'file', 'GITHUB_WORKSPACE', 'file');
+        }
         // Deploy it to the configured site
         await api.themes.upload({ file: zipPath });
         info(`${zipPath} successfully uploaded.`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,109 @@ import * as exec from '@actions/exec';
 import slug from 'slug';
 import GhostAdminApi from '@tryghost/admin-api';
 
+function isWithin(directory: string, candidate: string): boolean {
+    const relativePath = path.relative(directory, candidate);
+    return (
+        relativePath === '' ||
+        (relativePath !== '..' &&
+            !relativePath.startsWith(`..${path.sep}`) &&
+            !path.isAbsolute(relativePath))
+    );
+}
+
+function resolveExistingPathWithin(
+    resolutionDirectory: string,
+    boundaryDirectory: string,
+    inputPath: string,
+    inputName: string,
+    boundaryName: string,
+    expectedType: 'directory' | 'file',
+): string {
+    const candidate = path.resolve(resolutionDirectory, inputPath || '.');
+    if (path.isAbsolute(inputPath) || !isWithin(boundaryDirectory, candidate)) {
+        throw new Error(`${inputName} must resolve within ${boundaryName}`);
+    }
+
+    const realDirectory = fs.realpathSync(boundaryDirectory);
+    const realCandidate = fs.realpathSync(candidate);
+    if (!isWithin(realDirectory, realCandidate)) {
+        throw new Error(`${inputName} must resolve within ${boundaryName}`);
+    }
+
+    const candidateStats = fs.statSync(realCandidate);
+    if (expectedType === 'directory' && !candidateStats.isDirectory()) {
+        throw new Error(`${inputName} must be a directory`);
+    }
+    if (expectedType === 'file' && !candidateStats.isFile()) {
+        throw new Error(`${inputName} must be a regular file`);
+    }
+
+    return candidate;
+}
+
+function assertSafeThemeName(themeName: string): void {
+    const containsControlCharacter = [...themeName].some((character) => {
+        const codePoint = character.charCodeAt(0);
+        return codePoint <= 0x1f || codePoint === 0x7f;
+    });
+    if (
+        !themeName ||
+        themeName === '.' ||
+        themeName === '..' ||
+        themeName.startsWith('-') ||
+        /[/\\]/.test(themeName) ||
+        containsControlCharacter
+    ) {
+        throw new Error('theme-name must be a name, not a path');
+    }
+}
+
+function prepareArchivePath(directory: string, themeName: string): string {
+    const archivePath = path.resolve(directory, `${themeName}.zip`);
+    if (fs.existsSync(archivePath)) {
+        const archiveStats = fs.lstatSync(archivePath);
+        if (!archiveStats.isFile() || archiveStats.isSymbolicLink()) {
+            throw new Error('Generated archive path must be a regular file');
+        }
+        fs.unlinkSync(archivePath);
+    }
+
+    return archivePath;
+}
+
+function isBuiltInExcluded(relativePath: string): boolean {
+    const archivePath = relativePath.split(path.sep).join('/');
+    return (
+        archivePath.includes('.git') ||
+        archivePath.endsWith('.zip') ||
+        /^(?:yarn|npm|pnpm|node_modules)/.test(archivePath) ||
+        archivePath === 'AGENTS.md' ||
+        archivePath === 'CLAUDE.md' ||
+        archivePath === 'pnpm-workspace.yaml' ||
+        archivePath.endsWith('routes.yaml') ||
+        archivePath.endsWith('redirects.yaml') ||
+        archivePath.endsWith('redirects.json')
+    );
+}
+
+function assertSafeThemeSource(directory: string, currentDirectory = directory): void {
+    for (const entry of fs.readdirSync(currentDirectory, { withFileTypes: true })) {
+        const entryPath = path.join(currentDirectory, entry.name);
+        const relativePath = path.relative(directory, entryPath);
+        if (isBuiltInExcluded(relativePath)) {
+            continue;
+        }
+        if (entry.isSymbolicLink()) {
+            throw new Error(`Theme source must not contain symlinks: ${relativePath}`);
+        }
+        if (entry.isDirectory()) {
+            assertSafeThemeSource(directory, entryPath);
+        } else if (!entry.isFile()) {
+            throw new Error(`Theme source contains an unsupported file: ${relativePath}`);
+        }
+    }
+}
+
 export async function run(): Promise<void> {
     try {
         const url = core.getInput('api-url');
@@ -13,29 +116,54 @@ export async function run(): Promise<void> {
             key: core.getInput('api-key'),
             version: core.getInput('version') || 'v6.0',
         });
-        const workingDir = core.getInput('working-directory');
-        const basePath = path.join(process.env.GITHUB_WORKSPACE ?? '', workingDir);
-        const pkgPath = path.join(basePath, 'package.json');
+        const workspace = process.env.GITHUB_WORKSPACE;
+        if (!workspace) {
+            throw new Error('GITHUB_WORKSPACE is not set');
+        }
+
+        const workspacePath = path.resolve(workspace);
+        fs.realpathSync(workspacePath);
+        const basePath = resolveExistingPathWithin(
+            workspacePath,
+            workspacePath,
+            core.getInput('working-directory'),
+            'working-directory',
+            'GITHUB_WORKSPACE',
+            'directory',
+        );
 
         let zipPath = core.getInput('file');
 
         // Zip file was not provided - zip everything up!
         if (!zipPath) {
-            const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as { name: string };
+            const pkgPath = resolveExistingPathWithin(
+                basePath,
+                workspacePath,
+                'package.json',
+                'package.json',
+                'GITHUB_WORKSPACE',
+                'file',
+            );
+            const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as { name?: unknown };
+            if (typeof pkg.name !== 'string' || !pkg.name.trim()) {
+                throw new Error('package.json must contain a non-empty string name');
+            }
             const themeName = core.getInput('theme-name') || slug(pkg.name);
+            assertSafeThemeName(themeName);
             const themeZip = `${themeName}.zip`;
             const excludeRaw = core.getInput('exclude').trim();
             const excludeArgs = excludeRaw ? excludeRaw.split(/\s+/) : [];
             if (excludeArgs.some((pattern) => pattern.startsWith('-'))) {
                 throw new Error('Invalid exclude pattern: option-like values are not allowed');
             }
-            zipPath = themeZip;
-
+            assertSafeThemeSource(basePath);
+            zipPath = prepareArchivePath(basePath, themeName);
             // Create a zip
             await exec.exec(
                 'zip',
                 [
                     '-r',
+                    '-y',
                     themeZip,
                     '.',
                     '-x',
@@ -55,9 +183,19 @@ export async function run(): Promise<void> {
                 ],
                 { cwd: basePath },
             );
+            if (!fs.lstatSync(zipPath).isFile()) {
+                throw new Error('Generated archive path must be a regular file');
+            }
+        } else {
+            zipPath = resolveExistingPathWithin(
+                basePath,
+                workspacePath,
+                zipPath,
+                'file',
+                'GITHUB_WORKSPACE',
+                'file',
+            );
         }
-
-        zipPath = path.join(basePath, zipPath);
 
         // Deploy it to the configured site
         await api.themes.upload({ file: zipPath });

--- a/test/main.acceptance.test.ts
+++ b/test/main.acceptance.test.ts
@@ -31,15 +31,18 @@ vi.mock(import('@tryghost/admin-api'), () => ({
 import { run } from '../src/main';
 
 describe('theme packaging acceptance', () => {
+    let externalPaths: string[];
+    let inputs: Record<string, string>;
     let workspace: string;
     let previousWorkspace: string | undefined;
 
     beforeEach(() => {
+        externalPaths = [];
         workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'deploy-theme-acceptance-'));
         previousWorkspace = process.env.GITHUB_WORKSPACE;
         process.env.GITHUB_WORKSPACE = workspace;
 
-        const inputs: Record<string, string> = {
+        inputs = {
             'api-key': 'test-api-key',
             'api-url': 'https://example.test',
             exclude: 'private.txt',
@@ -55,6 +58,9 @@ describe('theme packaging acceptance', () => {
             process.env.GITHUB_WORKSPACE = previousWorkspace;
         }
         fs.rmSync(workspace, { force: true, recursive: true });
+        for (const externalPath of externalPaths) {
+            fs.rmSync(externalPath, { force: true, recursive: true });
+        }
     });
 
     it('creates a real archive containing only deployable theme files', async () => {
@@ -99,6 +105,84 @@ describe('theme packaging acceptance', () => {
         }
         expect(mocks.upload).toHaveBeenCalledWith({ file: zipPath });
         expect(mocks.info).toHaveBeenCalledWith(`${zipPath} successfully uploaded.`);
+        expect(mocks.setFailed).not.toHaveBeenCalled();
+    });
+
+    it('does not package a symlink to a file outside the workspace', async () => {
+        const externalDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'deploy-theme-external-'));
+        externalPaths.push(externalDirectory);
+        const externalFile = path.join(externalDirectory, 'secret.txt');
+        fs.writeFileSync(externalFile, 'secret');
+        fs.writeFileSync(path.join(workspace, 'package.json'), JSON.stringify({ name: 'theme' }));
+        fs.symlinkSync(externalFile, path.join(workspace, 'asset.txt'));
+
+        await run();
+
+        expect(mocks.setFailed).toHaveBeenCalledWith(
+            'Theme source must not contain symlinks: asset.txt',
+        );
+        expect(mocks.upload).not.toHaveBeenCalled();
+        expect(fs.existsSync(path.join(workspace, 'theme.zip'))).toBe(false);
+    });
+
+    it('ignores an excluded node_modules symlink without dereferencing it', async () => {
+        const externalDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'deploy-theme-external-'));
+        externalPaths.push(externalDirectory);
+        fs.writeFileSync(path.join(externalDirectory, 'secret.txt'), 'secret');
+        fs.writeFileSync(path.join(workspace, 'package.json'), JSON.stringify({ name: 'theme' }));
+        fs.writeFileSync(path.join(workspace, 'index.hbs'), 'theme');
+        fs.symlinkSync(externalDirectory, path.join(workspace, 'node_modules'));
+
+        await run();
+
+        const archiveFiles = execFileSync('unzip', ['-Z1', 'theme.zip'], {
+            cwd: workspace,
+            encoding: 'utf8',
+        })
+            .trim()
+            .split('\n');
+        expect(archiveFiles).toEqual(expect.arrayContaining(['package.json', 'index.hbs']));
+        expect(archiveFiles).not.toContain('node_modules/secret.txt');
+        expect(mocks.setFailed).not.toHaveBeenCalled();
+    });
+
+    it('rejects a nested node_modules symlink that the root exclusion does not match', async () => {
+        const externalDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'deploy-theme-external-'));
+        externalPaths.push(externalDirectory);
+        fs.writeFileSync(path.join(externalDirectory, 'secret.txt'), 'secret');
+        fs.writeFileSync(path.join(workspace, 'package.json'), JSON.stringify({ name: 'theme' }));
+        fs.mkdirSync(path.join(workspace, 'packages', 'theme'), { recursive: true });
+        fs.symlinkSync(
+            externalDirectory,
+            path.join(workspace, 'packages', 'theme', 'node_modules'),
+        );
+
+        await run();
+
+        expect(mocks.setFailed).toHaveBeenCalledWith(
+            `Theme source must not contain symlinks: ${path.join('packages', 'theme', 'node_modules')}`,
+        );
+        expect(mocks.upload).not.toHaveBeenCalled();
+        expect(fs.existsSync(path.join(workspace, 'theme.zip'))).toBe(false);
+    });
+
+    it('rebuilds an existing archive without retaining stale entries', async () => {
+        fs.writeFileSync(path.join(workspace, 'package.json'), JSON.stringify({ name: 'theme' }));
+        fs.writeFileSync(path.join(workspace, 'index.hbs'), 'theme');
+        fs.writeFileSync(path.join(workspace, 'stale-secret.txt'), 'secret');
+        execFileSync('zip', ['theme.zip', 'stale-secret.txt'], { cwd: workspace });
+        fs.rmSync(path.join(workspace, 'stale-secret.txt'));
+
+        await run();
+
+        const archiveFiles = execFileSync('unzip', ['-Z1', 'theme.zip'], {
+            cwd: workspace,
+            encoding: 'utf8',
+        })
+            .trim()
+            .split('\n');
+        expect(archiveFiles).toEqual(expect.arrayContaining(['package.json', 'index.hbs']));
+        expect(archiveFiles).not.toContain('stale-secret.txt');
         expect(mocks.setFailed).not.toHaveBeenCalled();
     });
 });

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -50,11 +51,13 @@ const defaultExcludeArgs = [
 ];
 
 describe('run', () => {
+    let externalPaths: string[];
     let workspace: string;
     let inputs: Record<string, string>;
     let previousWorkspace: string | undefined;
 
     beforeEach(() => {
+        externalPaths = [];
         workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'deploy-theme-unit-'));
         previousWorkspace = process.env.GITHUB_WORKSPACE;
         process.env.GITHUB_WORKSPACE = workspace;
@@ -64,7 +67,12 @@ describe('run', () => {
         };
 
         mocks.getInput.mockImplementation((name: string) => inputs[name] ?? '');
-        mocks.exec.mockResolvedValue(0);
+        mocks.exec.mockImplementation(
+            async (_command: string, args: string[], options: { cwd: string }) => {
+                fs.writeFileSync(path.join(options.cwd, args[2]), 'zip');
+                return 0;
+            },
+        );
         mocks.upload.mockResolvedValue(undefined);
     });
 
@@ -75,6 +83,9 @@ describe('run', () => {
             process.env.GITHUB_WORKSPACE = previousWorkspace;
         }
         fs.rmSync(workspace, { force: true, recursive: true });
+        for (const externalPath of externalPaths) {
+            fs.rmSync(externalPath, { force: true, recursive: true });
+        }
     });
 
     it('packages and uploads a theme using the default inputs', async () => {
@@ -93,7 +104,7 @@ describe('run', () => {
         });
         expect(mocks.exec).toHaveBeenCalledWith(
             'zip',
-            ['-r', 'my-theme.zip', '.', '-x', ...defaultExcludeArgs],
+            ['-r', '-y', 'my-theme.zip', '.', '-x', ...defaultExcludeArgs],
             { cwd: workspace },
         );
         expect(mocks.upload).toHaveBeenCalledWith({ file: zipPath });
@@ -126,6 +137,7 @@ describe('run', () => {
             'zip',
             [
                 '-r',
+                '-y',
                 'custom-casper.zip',
                 '.',
                 '-x',
@@ -141,6 +153,8 @@ describe('run', () => {
     });
 
     it('uploads a prebuilt file without reading or packaging the theme', async () => {
+        fs.mkdirSync(path.join(workspace, 'build'));
+        fs.writeFileSync(path.join(workspace, 'build', 'theme.zip'), 'zip');
         Object.assign(inputs, {
             exclude: '--ignored-for-prebuilt-files',
             file: 'build/theme.zip',
@@ -154,6 +168,229 @@ describe('run', () => {
             file: path.join(workspace, 'build/theme.zip'),
         });
         expect(mocks.setFailed).not.toHaveBeenCalled();
+    });
+
+    it('rejects a working directory outside the workspace', async () => {
+        const externalDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'deploy-theme-external-'));
+        externalPaths.push(externalDirectory);
+        inputs['working-directory'] = path.relative(workspace, externalDirectory);
+
+        await run();
+
+        expect(mocks.setFailed).toHaveBeenCalledWith(
+            'working-directory must resolve within GITHUB_WORKSPACE',
+        );
+        expect(mocks.exec).not.toHaveBeenCalled();
+        expect(mocks.upload).not.toHaveBeenCalled();
+    });
+
+    it('requires GITHUB_WORKSPACE', async () => {
+        delete process.env.GITHUB_WORKSPACE;
+
+        await run();
+
+        expect(mocks.setFailed).toHaveBeenCalledWith('GITHUB_WORKSPACE is not set');
+        expect(mocks.exec).not.toHaveBeenCalled();
+        expect(mocks.upload).not.toHaveBeenCalled();
+    });
+
+    it('requires working-directory to be a directory', async () => {
+        fs.writeFileSync(path.join(workspace, 'theme'), 'not a directory');
+        inputs['working-directory'] = 'theme';
+
+        await run();
+
+        expect(mocks.setFailed).toHaveBeenCalledWith('working-directory must be a directory');
+        expect(mocks.exec).not.toHaveBeenCalled();
+        expect(mocks.upload).not.toHaveBeenCalled();
+    });
+
+    it('rejects a working-directory symlink that escapes the workspace', async () => {
+        const externalDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'deploy-theme-external-'));
+        externalPaths.push(externalDirectory);
+        fs.symlinkSync(externalDirectory, path.join(workspace, 'theme'));
+        inputs['working-directory'] = 'theme';
+
+        await run();
+
+        expect(mocks.setFailed).toHaveBeenCalledWith(
+            'working-directory must resolve within GITHUB_WORKSPACE',
+        );
+        expect(mocks.exec).not.toHaveBeenCalled();
+        expect(mocks.upload).not.toHaveBeenCalled();
+    });
+
+    it('rejects a prebuilt file outside the working directory', async () => {
+        const externalDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'deploy-theme-external-'));
+        externalPaths.push(externalDirectory);
+        const externalZip = path.join(externalDirectory, 'theme.zip');
+        fs.writeFileSync(externalZip, 'zip');
+        inputs.file = path.relative(workspace, externalZip);
+
+        await run();
+
+        expect(mocks.setFailed).toHaveBeenCalledWith('file must resolve within GITHUB_WORKSPACE');
+        expect(mocks.upload).not.toHaveBeenCalled();
+    });
+
+    it('rejects a prebuilt-file symlink that escapes the working directory', async () => {
+        const externalDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'deploy-theme-external-'));
+        externalPaths.push(externalDirectory);
+        const externalZip = path.join(externalDirectory, 'theme.zip');
+        fs.writeFileSync(externalZip, 'zip');
+        fs.symlinkSync(externalZip, path.join(workspace, 'theme.zip'));
+        inputs.file = 'theme.zip';
+
+        await run();
+
+        expect(mocks.setFailed).toHaveBeenCalledWith('file must resolve within GITHUB_WORKSPACE');
+        expect(mocks.upload).not.toHaveBeenCalled();
+    });
+
+    it('allows a prebuilt file elsewhere inside the workspace', async () => {
+        fs.mkdirSync(path.join(workspace, 'theme'));
+        fs.writeFileSync(path.join(workspace, 'theme.zip'), 'zip');
+        inputs['working-directory'] = 'theme';
+        inputs.file = '../theme.zip';
+
+        await run();
+
+        expect(mocks.upload).toHaveBeenCalledWith({
+            file: path.join(workspace, 'theme.zip'),
+        });
+        expect(mocks.setFailed).not.toHaveBeenCalled();
+    });
+
+    it('requires a prebuilt file to be a regular file', async () => {
+        fs.mkdirSync(path.join(workspace, 'theme.zip'));
+        inputs.file = 'theme.zip';
+
+        await run();
+
+        expect(mocks.setFailed).toHaveBeenCalledWith('file must be a regular file');
+        expect(mocks.upload).not.toHaveBeenCalled();
+    });
+
+    it('rejects a theme name that writes outside the working directory', async () => {
+        fs.writeFileSync(path.join(workspace, 'package.json'), JSON.stringify({ name: 'casper' }));
+        inputs['theme-name'] = '../theme';
+
+        await run();
+
+        expect(mocks.setFailed).toHaveBeenCalledWith('theme-name must be a name, not a path');
+        expect(mocks.exec).not.toHaveBeenCalled();
+        expect(mocks.upload).not.toHaveBeenCalled();
+    });
+
+    it.each(['-theme', 'theme\\nested', 'theme\nnested', '.', '..'])(
+        'rejects the unsafe theme name %j',
+        async (themeName) => {
+            fs.writeFileSync(
+                path.join(workspace, 'package.json'),
+                JSON.stringify({ name: 'casper' }),
+            );
+            inputs['theme-name'] = themeName;
+
+            await run();
+
+            expect(mocks.setFailed).toHaveBeenCalledWith('theme-name must be a name, not a path');
+            expect(mocks.exec).not.toHaveBeenCalled();
+            expect(mocks.upload).not.toHaveBeenCalled();
+        },
+    );
+
+    it('rejects an archive output symlink', async () => {
+        const externalDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'deploy-theme-external-'));
+        externalPaths.push(externalDirectory);
+        const externalZip = path.join(externalDirectory, 'casper.zip');
+        fs.writeFileSync(externalZip, 'zip');
+        fs.writeFileSync(path.join(workspace, 'package.json'), JSON.stringify({ name: 'casper' }));
+        fs.symlinkSync(externalZip, path.join(workspace, 'casper.zip'));
+
+        await run();
+
+        expect(mocks.setFailed).toHaveBeenCalledWith(
+            'Generated archive path must be a regular file',
+        );
+        expect(mocks.exec).not.toHaveBeenCalled();
+        expect(mocks.upload).not.toHaveBeenCalled();
+    });
+
+    it('removes an existing generated archive before rebuilding it', async () => {
+        fs.writeFileSync(path.join(workspace, 'package.json'), JSON.stringify({ name: 'casper' }));
+        fs.writeFileSync(path.join(workspace, 'casper.zip'), 'stale');
+        mocks.exec.mockImplementationOnce(
+            async (_command: string, args: string[], options: { cwd: string }) => {
+                const archivePath = path.join(options.cwd, args[2]);
+                expect(fs.existsSync(archivePath)).toBe(false);
+                fs.writeFileSync(archivePath, 'fresh');
+                return 0;
+            },
+        );
+
+        await run();
+
+        expect(fs.readFileSync(path.join(workspace, 'casper.zip'), 'utf8')).toBe('fresh');
+        expect(mocks.setFailed).not.toHaveBeenCalled();
+    });
+
+    it('rejects a symlink in the packaged theme source', async () => {
+        const externalDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'deploy-theme-external-'));
+        externalPaths.push(externalDirectory);
+        const externalFile = path.join(externalDirectory, 'secret.txt');
+        fs.writeFileSync(externalFile, 'secret');
+        fs.writeFileSync(path.join(workspace, 'package.json'), JSON.stringify({ name: 'casper' }));
+        fs.symlinkSync(externalFile, path.join(workspace, 'asset.txt'));
+
+        await run();
+
+        expect(mocks.setFailed).toHaveBeenCalledWith(
+            'Theme source must not contain symlinks: asset.txt',
+        );
+        expect(mocks.exec).not.toHaveBeenCalled();
+        expect(mocks.upload).not.toHaveBeenCalled();
+    });
+
+    it('rejects unsupported files in the packaged theme source', async () => {
+        fs.writeFileSync(path.join(workspace, 'package.json'), JSON.stringify({ name: 'casper' }));
+        execFileSync('mkfifo', [path.join(workspace, 'theme.pipe')]);
+
+        await run();
+
+        expect(mocks.setFailed).toHaveBeenCalledWith(
+            'Theme source contains an unsupported file: theme.pipe',
+        );
+        expect(mocks.exec).not.toHaveBeenCalled();
+        expect(mocks.upload).not.toHaveBeenCalled();
+    });
+
+    it('requires package.json to contain a non-empty string name', async () => {
+        fs.writeFileSync(path.join(workspace, 'package.json'), JSON.stringify({ name: 42 }));
+
+        await run();
+
+        expect(mocks.setFailed).toHaveBeenCalledWith(
+            'package.json must contain a non-empty string name',
+        );
+        expect(mocks.exec).not.toHaveBeenCalled();
+        expect(mocks.upload).not.toHaveBeenCalled();
+    });
+
+    it('rejects a generated archive that is not a regular file', async () => {
+        fs.writeFileSync(path.join(workspace, 'package.json'), JSON.stringify({ name: 'casper' }));
+        mocks.exec.mockImplementationOnce(
+            async (_command: string, args: string[], options: { cwd: string }) => {
+                fs.mkdirSync(path.join(options.cwd, args[2]));
+                return 0;
+            },
+        );
+
+        await run();
+
+        expect(mocks.setFailed).toHaveBeenCalledWith(
+            'Generated archive path must be a regular file',
+        );
+        expect(mocks.upload).not.toHaveBeenCalled();
     });
 
     it('rejects option-like exclude patterns before invoking zip', async () => {
@@ -201,6 +438,7 @@ describe('run', () => {
 
     it('stringifies a non-Error upload failure', async () => {
         inputs.file = 'theme.zip';
+        fs.writeFileSync(path.join(workspace, 'theme.zip'), 'zip');
         mocks.upload.mockRejectedValue('upload unavailable');
 
         await run();


### PR DESCRIPTION
## Why

Action inputs could resolve outside `GITHUB_WORKSPACE`, and Info-ZIP followed included symlinks while packaging. Existing generated archives were updated in place, allowing stale entries to survive rebuilds.

## What changed

- require and canonicalize `GITHUB_WORKSPACE`
- constrain `working-directory`, `file`, and `package.json` to the workspace, including symlink resolution
- require regular files/directories and filename-safe theme names
- reject packaged source symlinks and unsupported filesystem nodes
- use `zip -y` as race defense, reject archive-output symlinks, and recreate existing archives from scratch
- document the tightened path, symlink, and trusted-prebuilt-archive contract
- add unit and real-zip regressions for traversal, external symlinks, nested exclusion semantics, and stale entries

## Validation

- `pnpm preship`
- 34 tests; 100% statements, branches, functions, and lines
- `pnpm audit --audit-level high`
- independent NCC build matches committed `dist/index.js` byte-for-byte
- `git diff --check`
- independent security-focused review approved