### PR TITLE
Align oxlint and oxfmt with the shared baseline

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,5 +1,17 @@
 {
   "$schema": "./node_modules/oxfmt/configuration_schema.json",
-  "ignorePatterns": ["dist"],
-  "singleQuote": true
+  "singleQuote": true,
+  "tabWidth": 4,
+  "sortPackageJson": false,
+  "ignorePatterns": [
+    "**/node_modules/**",
+    "**/coverage/**",
+    "**/dist/**",
+    "pnpm-lock.yaml",
+    "**/*.json",
+    "**/*.jsonc",
+    "**/*.yml",
+    "**/*.yaml",
+    "**/*.md"
+  ]
 }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "ignorePatterns": ["dist"],
+  "ignorePatterns": ["coverage", "dist"],
   "categories": {
     "correctness": "error",
     "suspicious": "warn"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "ncc build src/index.ts",
-    "lint": "oxlint && oxfmt --check .",
+    "lint": "oxlint --quiet && oxfmt --check .",
     "lint:fix": "oxlint --fix && oxfmt .",
     "format": "oxfmt .",
     "test": "vitest run",


### PR DESCRIPTION
## What changed

This aligns the existing oxlint/oxfmt setup with the shared repository baseline:

- run `oxlint --quiet` so successful lint output stays focused on errors
- preserve the repository four-space indentation setting
- disable package manifest sorting
- scope oxfmt to authored JavaScript and TypeScript, excluding generated output, dependencies, lockfiles, JSON/JSONC, YAML, and Markdown
- exclude generated coverage output from oxlint

This refines existing tooling rather than introducing first-time linting. The Node + ES2024 environment and `no-console` rule remain unchanged. There are no old ESLint or Prettier artifacts to remove. CI already runs `pnpm lint` through the validate job, which is included in `Required checks pass`, so no workflow change is needed.

## Validation

- `pnpm preship`
- `pnpm audit --audit-level high`
- committed `dist/` unchanged after build
- `git diff --check`
- no ESLint or Prettier artifacts/usages
- independent baseline review approved